### PR TITLE
Use current ruby versions for testing

### DIFF
--- a/.github/workflows/baseline-test.yml
+++ b/.github/workflows/baseline-test.yml
@@ -10,7 +10,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ruby-version: ['3.0', '3.1', '3.2']
+        ruby-version: ['3.0', '3.1']
 
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/baseline-test.yml
+++ b/.github/workflows/baseline-test.yml
@@ -10,7 +10,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ruby-version: ['2.6', '2.7', '3.0']
+        ruby-version: ['3.0', '3.1', '3.2']
 
     steps:
     - uses: actions/checkout@v2


### PR DESCRIPTION
Ruby 3.2 was released on 24.12.2022. Since then our tests for older ruby version were broken. According to https://endoflife.date/ruby the currently supported versions are 3.0, 3.1 and 3.2. 3.2 is still very new and there are some packages not working in CI. Ruby 2.6 was deprecated almost 9 months ago, 2.7 will be deprected in 3 months. 

updates tssted in a separate PR: https://github.com/dev-sec/linux-baseline/pull/181/checks